### PR TITLE
Add an Overlay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,10 @@ path = "examples/text/text.rs"
 name = "events"
 path = "examples/events/events.rs"
 
+[[example]]
+name = "overlay"
+path = "examples/overlay/overlay.rs"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/crates/craft_core/src/devtools/dev_tools_element.rs
+++ b/crates/craft_core/src/devtools/dev_tools_element.rs
@@ -9,8 +9,9 @@ use crate::events::CraftMessage;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
 use crate::renderer::color::Color;
+use crate::renderer::renderer::RenderList;
 use crate::style::Style;
-use crate::{generate_component_methods, RendererBox};
+use crate::generate_component_methods;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -61,7 +62,7 @@ impl Element for DevTools {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/devtools/element_tree_view.rs
+++ b/crates/craft_core/src/devtools/element_tree_view.rs
@@ -73,6 +73,24 @@ pub(crate) fn element_tree_view(
             );
         }
 
+
+        let user_id_color = Color::from_rgb8(68, 147, 248);
+        row = row.push(
+            Container::new()
+                .push(
+                    Text::new(element.component_id().to_string().as_str())
+                        .color(Color::WHITE)
+                        .margin("2.5px", "10px", "2.5px", "10px")
+                        .id(id.as_str()),
+                )
+                .id(id.as_str())
+                .border_width("2px", "2px", "2px", "2px")
+                .border_color(user_id_color)
+                .border_radius(100.0, 100.0, 100.0, 100.0)
+                .margin("0px", "0px", "0px", "5px")
+                .component(),
+        );
+
         element_tree = element_tree.push(row);
 
         let children = element.children();

--- a/crates/craft_core/src/elements/canvas.rs
+++ b/crates/craft_core/src/elements/canvas.rs
@@ -6,10 +6,11 @@ use crate::elements::element_styles::ElementStyles;
 use crate::elements::layout_context::LayoutContext;
 use crate::geometry::{Point, Rectangle};
 use crate::reactive::element_state_store::ElementStateStore;
+use crate::renderer::renderer::RenderList;
 use crate::renderer::RenderCommand;
 use crate::style::Style;
 use crate::Color;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -19,7 +20,7 @@ use winit::window::Window;
 #[derive(Clone, Default, Debug)]
 pub struct Canvas {
     pub element_data: ElementData,
-    pub render_commands: Vec<RenderCommand>,
+    pub render_list: Vec<RenderCommand>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -40,7 +41,7 @@ impl Element for Canvas {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,
@@ -77,7 +78,7 @@ impl Element for Canvas {
             computed_height - (border_top + border_bottom),
         ));
 
-        for render_command in self.render_commands.iter() {
+        for render_command in self.render_list.iter() {
             match render_command {
                 RenderCommand::DrawRect(rectangle, color) => {
                     let translated_rectangle = Rectangle::new(
@@ -220,7 +221,7 @@ impl Canvas {
     pub fn new() -> Canvas {
         Canvas {
             element_data: Default::default(),
-            render_commands: Vec::new(),
+            render_list: Vec::new(),
         }
     }
 

--- a/crates/craft_core/src/elements/canvas.rs
+++ b/crates/craft_core/src/elements/canvas.rs
@@ -133,6 +133,12 @@ impl Element for Canvas {
                 RenderCommand::DrawTinyVg(rectangle, resource_identifier) => {
                     renderer.draw_tiny_vg(*rectangle, resource_identifier.clone());
                 }
+                RenderCommand::StartOverlay => {
+                    renderer.start_overlay();
+                }
+                RenderCommand::EndOverlay => {
+                    renderer.end_overlay();
+                }    
             }
         }
 

--- a/crates/craft_core/src/elements/container.rs
+++ b/crates/craft_core/src/elements/container.rs
@@ -10,12 +10,13 @@ use crate::events::CraftMessage;
 use crate::geometry::{Point, Size};
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
 use crate::style::Style;
-use crate::{generate_component_methods, RendererBox};
+use crate::{generate_component_methods};
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use crate::renderer::renderer::RenderList;
 
 /// An element for storing related elements.
 #[derive(Clone, Default, Debug)]
@@ -43,7 +44,7 @@ impl Element for Container {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/dropdown.rs
+++ b/crates/craft_core/src/elements/dropdown.rs
@@ -109,6 +109,9 @@ impl Element for Dropdown {
                 );
             }
 
+            // CLEANUP: We could make pseudo_dropdown_list_element an Overlay, but below we draw the overlay then the children.
+            //          We didn't do that for any particular reason, mainly just because we need to add more abstractions around drawing.
+            renderer.start_overlay();
             // Draw the dropdown list if it is open.
             if is_open && !self.children().is_empty() {
                 self.pseudo_dropdown_list_element.draw(
@@ -122,6 +125,7 @@ impl Element for Dropdown {
                 );
                 self.draw_children(renderer, font_system, taffy_tree, element_state, pointer, window.clone());
             }
+            renderer.end_overlay();
         }
         self.maybe_end_layer(renderer);
     }

--- a/crates/craft_core/src/elements/dropdown.rs
+++ b/crates/craft_core/src/elements/dropdown.rs
@@ -9,8 +9,9 @@ use crate::elements::Container;
 use crate::events::CraftMessage;
 use crate::geometry::{Point, TrblRectangle};
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::renderer::renderer::RenderList;
 use crate::style::{AlignItems, Display, FlexDirection, Style, Unit};
-use crate::{generate_component_methods, RendererBox};
+use crate::generate_component_methods;
 use cosmic_text::FontSystem;
 use peniko::Color;
 use std::any::Any;
@@ -79,7 +80,7 @@ impl Element for Dropdown {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/element.rs
+++ b/crates/craft_core/src/elements/element.rs
@@ -8,15 +8,15 @@ use crate::geometry::borders::BorderSpec;
 use crate::geometry::side::Side;
 use crate::geometry::{Border, ElementBox, Margin, Padding, Point, Rectangle, Size};
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::renderer::renderer::RenderList;
+use crate::renderer::Brush;
 use crate::style::Style;
-use crate::RendererBox;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 use taffy::{NodeId, Overflow, Position, TaffyTree};
 use winit::window::Window;
-use crate::renderer::Brush;
 
 #[derive(Clone, Debug)]
 pub struct ElementBoxed {
@@ -78,7 +78,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
     #[allow(clippy::too_many_arguments)]
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         root_node: NodeId,
@@ -168,7 +168,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
 
     fn draw_children(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         element_state: &mut ElementStateStore,
@@ -193,7 +193,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
         }
     }
 
-    fn draw_borders(&self, renderer: &mut RendererBox) {
+    fn draw_borders(&self, renderer: &mut RenderList) {
         let element_data = self.element_data();
         let current_style = element_data.current_style();
         let background_color = current_style.background();
@@ -231,7 +231,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
         element_data.current_style().overflow()[1] == Overflow::Scroll
     }
 
-    fn maybe_start_layer(&self, renderer: &mut RendererBox) {
+    fn maybe_start_layer(&self, renderer: &mut RenderList) {
         let element_data = self.element_data();
         let padding_rectangle = element_data.computed_box_transformed.padding_rectangle();
 
@@ -240,7 +240,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
         }
     }
 
-    fn maybe_end_layer(&self, renderer: &mut RendererBox) {
+    fn maybe_end_layer(&self, renderer: &mut RenderList) {
         if self.should_start_new_layer() {
             renderer.pop_layer();
         }
@@ -265,7 +265,7 @@ pub(crate) trait Element: Any + StandardElementClone + Debug + Send + Sync {
         element_data.computed_border = border_spec.compute_border_spec();
     }
 
-    fn draw_scrollbar(&mut self, renderer: &mut RendererBox) {
+    fn draw_scrollbar(&mut self, renderer: &mut RenderList) {
         let scrollbar_color = self.element_data().current_style().scrollbar_color();
 
         // track

--- a/crates/craft_core/src/elements/empty.rs
+++ b/crates/craft_core/src/elements/empty.rs
@@ -3,7 +3,7 @@ use crate::elements::element_data::ElementData;
 use crate::elements::layout_context::LayoutContext;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::ElementStateStore;
-use crate::RendererBox;
+use crate::renderer::renderer::RenderList;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -39,7 +39,7 @@ impl Element for Empty {
 
     fn draw(
         &mut self,
-        _renderer: &mut RendererBox,
+        _renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/font.rs
+++ b/crates/craft_core/src/elements/font.rs
@@ -5,8 +5,9 @@ use crate::elements::element_data::ElementData;
 use crate::elements::layout_context::LayoutContext;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::ElementStateStore;
+use crate::renderer::renderer::RenderList;
 use crate::resource_manager::ResourceIdentifier;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -47,7 +48,7 @@ impl Element for Font {
 
     fn draw(
         &mut self,
-        _renderer: &mut RendererBox,
+        _renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/image.rs
+++ b/crates/craft_core/src/elements/image.rs
@@ -6,9 +6,10 @@ use crate::elements::layout_context::{ImageContext, LayoutContext};
 use crate::elements::ElementStyles;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::ElementStateStore;
+use crate::renderer::renderer::RenderList;
 use crate::resource_manager::ResourceIdentifier;
 use crate::style::Style;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -49,7 +50,7 @@ impl Element for Image {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/mod.rs
+++ b/crates/craft_core/src/elements/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod container;
+pub(crate) mod overlay;
 pub(crate) mod dropdown;
 pub(crate) mod element;
 pub(crate) mod empty;
@@ -26,6 +27,7 @@ mod thumb;
 
 pub use crate::elements::canvas::Canvas;
 pub use crate::elements::container::Container;
+pub use crate::elements::overlay::Overlay;
 pub use crate::elements::dropdown::Dropdown;
 pub use crate::elements::element_styles::ElementStyles;
 pub use crate::elements::font::Font;

--- a/crates/craft_core/src/elements/overlay.rs
+++ b/crates/craft_core/src/elements/overlay.rs
@@ -1,0 +1,166 @@
+use crate::components::component::ComponentSpecification;
+use crate::components::Props;
+use crate::components::UpdateResult;
+use crate::elements::element::Element;
+use crate::elements::element_data::ElementData;
+use crate::elements::element_styles::ElementStyles;
+use crate::elements::layout_context::LayoutContext;
+use crate::events::CraftMessage;
+use crate::geometry::Point;
+use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::style::Style;
+use crate::{generate_component_methods, RendererBox};
+use cosmic_text::FontSystem;
+use std::any::Any;
+use std::sync::Arc;
+use taffy::{NodeId, TaffyTree};
+use winit::window::Window;
+
+/// An element for storing related elements.
+#[derive(Clone, Default, Debug)]
+pub struct Overlay {
+    pub element_data: ElementData,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct OverlayState {
+}
+
+impl Element for Overlay {
+    fn element_data(&self) -> &ElementData {
+        &self.element_data
+    }
+
+    fn element_data_mut(&mut self) -> &mut ElementData {
+        &mut self.element_data
+    }
+
+    fn name(&self) -> &'static str {
+        "Overlay"
+    }
+
+    fn draw(
+        &mut self,
+        renderer: &mut RendererBox,
+        font_system: &mut FontSystem,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        _root_node: NodeId,
+        element_state: &mut ElementStateStore,
+        pointer: Option<Point>,
+        window: Option<Arc<dyn Window>>,
+    ) {
+        if !self.element_data.style.visible() {
+            return;
+        }
+        renderer.start_overlay();
+        
+        // We draw the borders before we start any layers, so that we don't clip the borders.
+        self.draw_borders(renderer);
+        self.maybe_start_layer(renderer);
+        {
+            self.draw_children(renderer, font_system, taffy_tree, element_state, pointer, window);
+        }
+        self.maybe_end_layer(renderer);
+        self.draw_scrollbar(renderer);
+        
+        renderer.end_overlay();
+    }
+
+    fn compute_layout(
+        &mut self,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        element_state: &mut ElementStateStore,
+        scale_factor: f64,
+    ) -> Option<NodeId> {
+        self.merge_default_style();
+        let mut child_nodes: Vec<NodeId> = Vec::with_capacity(self.children().len());
+
+        for child in self.element_data.children.iter_mut() {
+            let child_node = child.internal.compute_layout(taffy_tree, element_state, scale_factor);
+            if let Some(child_node) = child_node {
+                child_nodes.push(child_node);
+            }
+        }
+
+        let style: taffy::Style = self.element_data.style.to_taffy_style_with_scale_factor(scale_factor);
+
+        self.element_data_mut().taffy_node_id = Some(taffy_tree.new_with_children(style, &child_nodes).unwrap());
+        self.element_data().taffy_node_id
+    }
+
+    fn finalize_layout(
+        &mut self,
+        taffy_tree: &mut TaffyTree<LayoutContext>,
+        root_node: NodeId,
+        position: Point,
+        z_index: &mut u32,
+        transform: glam::Mat4,
+        element_state: &mut ElementStateStore,
+        pointer: Option<Point>,
+        font_system: &mut FontSystem,
+    ) {
+        let result = taffy_tree.layout(root_node).unwrap();
+        self.resolve_box(position, transform, result, z_index);
+
+        self.finalize_borders();
+        
+        for child in self.element_data.children.iter_mut() {
+            let taffy_child_node_id = child.internal.element_data().taffy_node_id;
+            if taffy_child_node_id.is_none() {
+                continue;
+            }
+
+            child.internal.finalize_layout(
+                taffy_tree,
+                taffy_child_node_id.unwrap(),
+                self.element_data.computed_box.position,
+                z_index,
+                transform,
+                element_state,
+                pointer,
+                font_system,
+            );
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn on_event(
+        &self,
+        message: &CraftMessage,
+        element_state: &mut ElementStateStore,
+        _font_system: &mut FontSystem,
+    ) -> UpdateResult {
+        UpdateResult::default()
+    }
+
+    fn initialize_state(&self, _font_system: &mut FontSystem, _scaling_factor: f64) -> ElementStateStoreItem {
+        ElementStateStoreItem {
+            base: Default::default(),
+            data: Box::new(OverlayState::default()),
+        }
+    }
+}
+
+impl Overlay {
+    #[allow(dead_code)]
+    fn get_state<'a>(&self, element_state: &'a ElementStateStore) -> &'a OverlayState {
+        element_state.storage.get(&self.element_data.component_id).unwrap().data.as_ref().downcast_ref().unwrap()
+    }
+
+    pub fn new() -> Overlay {
+        Overlay {
+            element_data: Default::default(),
+        }
+    }
+
+    generate_component_methods!();
+}
+
+impl ElementStyles for Overlay {
+    fn styles_mut(&mut self) -> &mut Style {
+        self.element_data.current_style_mut()
+    }
+}

--- a/crates/craft_core/src/elements/overlay.rs
+++ b/crates/craft_core/src/elements/overlay.rs
@@ -9,12 +9,13 @@ use crate::events::CraftMessage;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
 use crate::style::Style;
-use crate::{generate_component_methods, RendererBox};
+use crate::{generate_component_methods};
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
 use taffy::{NodeId, TaffyTree};
 use winit::window::Window;
+use crate::renderer::renderer::RenderList;
 
 /// An element for storing related elements.
 #[derive(Clone, Default, Debug)]
@@ -41,7 +42,7 @@ impl Element for Overlay {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/slider.rs
+++ b/crates/craft_core/src/elements/slider.rs
@@ -11,8 +11,10 @@ use crate::events::CraftMessage;
 use crate::geometry::borders::BorderSpec;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::renderer::renderer::RenderList;
+use crate::renderer::Brush;
 use crate::style::{Display, Style, Unit};
-use crate::{generate_component_methods, palette, RendererBox};
+use crate::{generate_component_methods, palette};
 use cosmic_text::FontSystem;
 use peniko::Color;
 use std::any::Any;
@@ -20,7 +22,6 @@ use std::sync::Arc;
 use taffy::{NodeId, TaffyTree};
 use winit::event::ElementState;
 use winit::window::Window;
-use crate::renderer::Brush;
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub enum SliderDirection {
@@ -67,7 +68,7 @@ impl Element for Slider {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/switch.rs
+++ b/crates/craft_core/src/elements/switch.rs
@@ -8,9 +8,10 @@ use crate::elements::thumb::Thumb;
 use crate::events::CraftMessage;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::renderer::renderer::RenderList;
 use crate::style::{Display, Style, Unit};
 use crate::ComponentSpecification;
-use crate::{generate_component_methods_no_children, palette, RendererBox};
+use crate::{generate_component_methods_no_children, palette};
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -56,7 +57,7 @@ impl Element for Switch {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         font_system: &mut FontSystem,
         taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/text.rs
+++ b/crates/craft_core/src/elements/text.rs
@@ -7,9 +7,10 @@ use crate::elements::ElementStyles;
 use crate::events::CraftMessage;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
+use crate::renderer::renderer::RenderList;
 use crate::style::Style;
 use crate::text::cached_editor::CachedEditor;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use peniko::Color;
 use std::any::Any;
@@ -69,7 +70,7 @@ impl Element for Text {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/text_input.rs
+++ b/crates/craft_core/src/elements/text_input.rs
@@ -10,10 +10,11 @@ use crate::events::CraftMessage;
 use crate::geometry::{Point, Size, TrblRectangle};
 use crate::reactive::element_state_store::{ElementStateStore, ElementStateStoreItem};
 use crate::renderer::color::Color;
-use crate::renderer::renderer::TextScroll;
+use crate::renderer::renderer::{RenderList, TextScroll};
+use crate::renderer::text;
 use crate::style::{Display, Style, Unit};
 use crate::text::cached_editor::CachedEditor;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use cosmic_text::{Cursor, Edit};
 use std::any::Any;
@@ -23,7 +24,6 @@ use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::Ime;
 use winit::keyboard::{Key, NamedKey};
 use winit::window::Window;
-use crate::renderer::text;
 
 // A stateful element that shows text.
 #[derive(Clone, Default, Debug)]
@@ -83,7 +83,7 @@ impl Element for TextInput {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/elements/tinyvg.rs
+++ b/crates/craft_core/src/elements/tinyvg.rs
@@ -6,9 +6,10 @@ use crate::elements::layout_context::{LayoutContext, TinyVgContext};
 use crate::elements::ElementStyles;
 use crate::geometry::Point;
 use crate::reactive::element_state_store::ElementStateStore;
+use crate::renderer::renderer::RenderList;
 use crate::resource_manager::ResourceIdentifier;
 use crate::style::Style;
-use crate::{generate_component_methods_no_children, RendererBox};
+use crate::generate_component_methods_no_children;
 use cosmic_text::FontSystem;
 use std::any::Any;
 use std::sync::Arc;
@@ -49,7 +50,7 @@ impl Element for TinyVg {
 
     fn draw(
         &mut self,
-        renderer: &mut RendererBox,
+        renderer: &mut RenderList,
         _font_system: &mut FontSystem,
         _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,

--- a/crates/craft_core/src/lib.rs
+++ b/crates/craft_core/src/lib.rs
@@ -181,6 +181,7 @@ use crate::reactive::state_store::{StateStore, StateStoreItem};
 use crate::resource_manager::resource_type::ResourceType;
 use crate::view_introspection::scan_view_for_resources;
 use craft_winit_state::CraftWinitState;
+use crate::renderer::renderer::RenderList;
 use crate::resource_manager::ResourceIdentifier;
 
 pub(crate) type GlobalState = Box<dyn Any + Send + 'static>;
@@ -1073,8 +1074,9 @@ async fn draw_reactive_tree(
     {
         let span = span!(Level::INFO, "render");
         let _enter = span.enter();
+        let mut render_list = RenderList::new();
         root.draw(
-            renderer,
+            &mut render_list,
             font_system,
             &mut taffy_tree,
             taffy_root,
@@ -1082,7 +1084,8 @@ async fn draw_reactive_tree(
             mouse_position,
             window,
         );
-        renderer.prepare(resource_manager, font_system);
+        renderer.sort_render_list(&mut render_list);
+        renderer.prepare_render_list(render_list, resource_manager, font_system);
     }
 }
 

--- a/crates/craft_core/src/renderer/blank_renderer.rs
+++ b/crates/craft_core/src/renderer/blank_renderer.rs
@@ -46,6 +46,10 @@ impl Renderer for BlankRenderer {
 
     fn pop_layer(&mut self) {}
 
+    fn start_overlay(&mut self) {}
+
+    fn end_overlay(&mut self) {}
+
     fn prepare(
         &mut self,
         _resource_manager: Arc<ResourceManager>,

--- a/crates/craft_core/src/renderer/blank_renderer.rs
+++ b/crates/craft_core/src/renderer/blank_renderer.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 use crate::geometry::Rectangle;
 use crate::renderer::color::Color;
-use crate::renderer::renderer::{Renderer, TextScroll};
+use crate::renderer::renderer::{RenderList, Renderer, TextScroll};
 use crate::renderer::text::BufferGlyphs;
-use crate::renderer::Brush;
+use crate::renderer::{Brush, RenderCommand};
 use crate::resource_manager::{ResourceIdentifier, ResourceManager};
 use cosmic_text::FontSystem;
 use peniko::kurbo::BezPath;
@@ -23,39 +23,12 @@ impl Renderer for BlankRenderer {
 
     fn surface_set_clear_color(&mut self, _color: Color) {}
 
-    fn draw_rect(&mut self, _rectangle: Rectangle, _fill_color: Color) {}
-
-    fn draw_rect_outline(&mut self, _rectangle: Rectangle, _outline_color: Color) {}
-
-    fn fill_bez_path(&mut self, _path: BezPath, _brush: Brush) {}
-
-    fn draw_text(
+    fn prepare_render_list(
         &mut self,
-        _buffer_glyphs: BufferGlyphs,
-        _rectangle: Rectangle,
-        _text_scroll: Option<TextScroll>,
-        _show_cursor: bool,
-    ) {
-    }
-
-    fn draw_image(&mut self, _rectangle: Rectangle, _resource_identifier: ResourceIdentifier) {}
-
-    fn draw_tiny_vg(&mut self, _rectangle: Rectangle, _resource_identifier: ResourceIdentifier) {}
-
-    fn push_layer(&mut self, _rect: Rectangle) {}
-
-    fn pop_layer(&mut self) {}
-
-    fn start_overlay(&mut self) {}
-
-    fn end_overlay(&mut self) {}
-
-    fn prepare(
-        &mut self,
+        _render_list: RenderList,
         _resource_manager: Arc<ResourceManager>,
         _font_system: &mut FontSystem,
-    ) {
-    }
+    ) {}
 
     fn submit(&mut self, _resource_manager: Arc<ResourceManager>) {}
 }

--- a/crates/craft_core/src/renderer/renderer.rs
+++ b/crates/craft_core/src/renderer/renderer.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
 use crate::geometry::Rectangle;
 use crate::renderer::color::Color;
 use crate::renderer::text::BufferGlyphs;
 use crate::resource_manager::{ResourceIdentifier, ResourceManager};
 use cosmic_text::FontSystem;
 use peniko::{kurbo, BrushRef, Gradient};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub enum RenderCommand {
@@ -50,6 +50,100 @@ impl TextScroll {
     }
 }
 
+#[derive(Debug)]
+enum SortedItem {
+    Overlay(SortedCommands),
+    Other(u32)
+}
+
+#[derive(Debug)]
+pub struct SortedCommands {
+    children: Vec<SortedItem>,
+}
+
+impl SortedCommands {
+    pub fn draw(render_list: &RenderList, overlay_render: &SortedCommands, on_draw: &mut dyn FnMut(&RenderCommand)) {
+        let mut others = Vec::new();
+        let mut overlays = Vec::new();
+
+        for child in &overlay_render.children {
+            match child {
+                SortedItem::Other(_) => others.push(child),
+                SortedItem::Overlay(_) => overlays.push(child),
+            }
+        }
+
+        for child in others {
+            if let SortedItem::Other(command_index) = child {
+                let command = render_list.commands.get(*command_index as usize).unwrap();
+                on_draw(command);
+            }
+        }
+
+        for child in overlays {
+            if let SortedItem::Overlay(overlay) = child {
+                Self::draw(render_list, overlay, on_draw);
+            }
+        }
+    }
+}
+
+pub struct RenderList {
+    pub commands: Vec<RenderCommand>,
+    /// Stores a sorted list of render command handles. This gets set in `Renderer::sort_render_list`.
+    pub overlay: SortedCommands,
+}
+
+impl RenderList {
+    pub fn new() -> Self {
+        Self { commands: Vec::new(), overlay: SortedCommands { children: vec![] } }
+    }
+
+    pub fn draw_rect(&mut self, rectangle: Rectangle, fill_color: Color) {
+        self.commands.push(RenderCommand::DrawRect(rectangle, fill_color));
+    }
+    pub fn draw_rect_outline(&mut self, rectangle: Rectangle, outline_color: Color) {
+        self.commands.push(RenderCommand::DrawRectOutline(rectangle, outline_color));
+    }
+
+    pub fn fill_bez_path(&mut self, path: kurbo::BezPath, brush: Brush) {
+        self.commands.push(RenderCommand::FillBezPath(path, brush));
+    }
+
+    pub fn draw_text(
+        &mut self,
+        buffer_glyphs: BufferGlyphs,
+        rectangle: Rectangle,
+        text_scroll: Option<TextScroll>,
+        show_cursor: bool,
+    ) {
+        self.commands.push(RenderCommand::DrawText(buffer_glyphs, rectangle, text_scroll, show_cursor));
+    }
+    pub fn draw_image(&mut self, rectangle: Rectangle, resource_identifier: ResourceIdentifier) {
+        self.commands.push(RenderCommand::DrawImage(rectangle, resource_identifier));
+    }
+
+    pub fn draw_tiny_vg(&mut self, rectangle: Rectangle, resource_identifier: ResourceIdentifier) {
+        self.commands.push(RenderCommand::DrawTinyVg(rectangle, resource_identifier));
+    }
+
+    pub fn push_layer(&mut self, rect: Rectangle) {
+        self.commands.push(RenderCommand::PushLayer(rect));
+    }
+
+    pub fn pop_layer(&mut self) {
+        self.commands.push(RenderCommand::PopLayer);
+    }
+
+    pub fn start_overlay(&mut self) {
+        self.commands.push(RenderCommand::StartOverlay);
+    }
+
+    pub fn end_overlay(&mut self) {
+        self.commands.push(RenderCommand::EndOverlay);
+    }
+}
+
 pub trait Renderer {
     // Surface Functions
     #[allow(dead_code)]
@@ -59,31 +153,49 @@ pub trait Renderer {
     fn resize_surface(&mut self, width: f32, height: f32);
     fn surface_set_clear_color(&mut self, color: Color);
 
-    fn draw_rect(&mut self, rectangle: Rectangle, fill_color: Color);
-    fn draw_rect_outline(&mut self, rectangle: Rectangle, outline_color: Color);
+    fn sort_render_list(&mut self, render_list: &mut RenderList) {
+        let mut overlay_render = SortedCommands {
+            children: vec![],
+        };
 
-    fn fill_bez_path(&mut self, path: kurbo::BezPath, brush: Brush);
+        let mut current: *mut SortedCommands = &mut overlay_render;
+        let mut stack: Vec<*mut SortedCommands> = vec![current];
+        for (index, command) in render_list.commands.iter().enumerate() {
+            match &command {
+                RenderCommand::StartOverlay => {
+                    // Overlay Start
+                    unsafe {
+                        (*current).children.push(SortedItem::Overlay(SortedCommands { children: vec![] }));
+                        match (*current).children.last_mut(){
+                            Some(SortedItem::Overlay(overlay)) => {
+                                stack.push(overlay);
+                            }
+                            _ => {
+                                panic!("OverlayRender stack corrupted");
+                            }
+                        }
+                        current = *stack.last_mut().unwrap();
+                    }
+                }
+                RenderCommand::EndOverlay => {
+                    // Overlay End
+                    stack.pop();
+                    current = *stack.last_mut().unwrap();
+                }
+                _ => {
+                    // Normal Draw Command
+                    unsafe {
+                        (*current).children.push(SortedItem::Other(index as u32));
+                    }
+                }
+            }
 
-    fn draw_text(
+        }
+        render_list.overlay = overlay_render;
+    }
+    fn prepare_render_list(
         &mut self,
-        buffer_glyphs: BufferGlyphs,
-        rectangle: Rectangle,
-        text_scroll: Option<TextScroll>,
-        show_cursor: bool,
-    );
-    fn draw_image(&mut self, rectangle: Rectangle, resource_identifier: ResourceIdentifier);
-    fn draw_tiny_vg(&mut self, rectangle: Rectangle, resource_identifier: ResourceIdentifier);
-
-    fn push_layer(&mut self, rect: Rectangle);
-
-    fn pop_layer(&mut self);
-
-    fn start_overlay(&mut self);
-
-    fn end_overlay(&mut self);
-
-    fn prepare(
-        &mut self,
+        render_list: RenderList,
         resource_manager: Arc<ResourceManager>,
         font_system: &mut FontSystem,
     );

--- a/crates/craft_core/src/renderer/renderer.rs
+++ b/crates/craft_core/src/renderer/renderer.rs
@@ -16,6 +16,8 @@ pub enum RenderCommand {
     PushLayer(Rectangle),
     PopLayer,
     FillBezPath(kurbo::BezPath, Brush),
+    StartOverlay,
+    EndOverlay,
 }
 
 #[derive(Clone, Debug)]
@@ -75,6 +77,10 @@ pub trait Renderer {
     fn push_layer(&mut self, rect: Rectangle);
 
     fn pop_layer(&mut self);
+
+    fn start_overlay(&mut self);
+
+    fn end_overlay(&mut self);
 
     fn prepare(
         &mut self,

--- a/examples/overlay/overlay.rs
+++ b/examples/overlay/overlay.rs
@@ -1,0 +1,153 @@
+#[path = "../util.rs"]
+mod util;
+
+use craft::components::{Component, ComponentId, ComponentSpecification, UpdateResult};
+use craft::elements::{Container, Text};
+use craft::elements::ElementStyles;
+use craft::events::Event;
+use craft::style::Display;
+use craft::style::{AlignItems, FlexDirection, JustifyContent};
+use craft::Color;
+use craft::CraftOptions;
+use craft::RendererType;
+use craft::{craft_main_with_options, palette};
+
+#[derive(Default, Clone)]
+pub struct OverlayExample {
+    hovered_element_id: Option<String>
+}
+
+impl Component for OverlayExample {
+    type Props = ();
+
+    fn view_with_no_global_state(
+        state: &Self,
+        _props: &Self::Props,
+        _children: Vec<ComponentSpecification>,
+        _id: ComponentId,
+    ) -> ComponentSpecification {
+        Container::new()
+            .display(Display::Flex)
+            .flex_direction(FlexDirection::Column)
+            .justify_content(JustifyContent::Center)
+            .align_items(AlignItems::Center)
+            .width("100%")
+            .height("100%")
+            .background(Color::from_rgb8(250, 250, 250))
+
+            .push(Text::new(format!("Hovered Element: {:?}", state.hovered_element_id).as_str()))
+            .push(
+                Container::new()
+                    .background(palette::css::RED)
+                    .width(Unit::Px(400.0))
+                    .height(Unit::Px(400.0))
+                    .id("red")
+                    .push(
+                        Overlay::new()
+                            .background(palette::css::GREEN)
+                            .inset(Unit::Px(50.0), Unit::Px(50.0), Unit::Px(50.0), Unit::Px(50.0))
+                            .position(Position::Absolute)
+                            .width(Unit::Px(200.0))
+                            .height(Unit::Px(200.0))
+                            .id("green")
+                            .push(
+                                Overlay::new()
+                                    .background(palette::css::YELLOW)
+                                    .inset(Unit::Px(50.0), Unit::Px(50.0), Unit::Px(50.0), Unit::Px(50.0))
+                                    .position(Position::Absolute)
+                                    .width(Unit::Px(100.0))
+                                    .height(Unit::Px(100.0))
+                                    .id("yellow"),
+                            )
+                            .push(
+                                Container::new()
+                                    .background(palette::css::PINK)
+                                    .inset(Unit::Px(25.0), Unit::Px(25.0), Unit::Px(25.0), Unit::Px(25.0))
+                                    .position(Position::Absolute)
+                                    .width(Unit::Px(50.0))
+                                    .height(Unit::Px(50.0))
+                                    .id("pink")
+                                ,
+                            )
+                        ,
+                    )
+                    .push(
+                        Container::new()
+                            .background(palette::css::BLUE)
+                            .inset(Unit::Px(0.0), Unit::Px(0.0), Unit::Px(0.0), Unit::Px(0.0))
+                            .position(Position::Absolute)
+                            .width(Unit::Px(100.0))
+                            .height(Unit::Px(100.0))
+                            .id("blue")
+                        ,
+                    )
+            )
+
+            .component()
+    }
+
+    fn update_with_no_global_state(state: &mut Self, _props: &Self::Props, event: Event) -> UpdateResult { 
+        state.hovered_element_id = event.target;
+        
+        if state.hovered_element_id.is_some() {
+            return UpdateResult::new().prevent_propagate();
+        }
+        
+       UpdateResult::default()
+    }
+}
+
+fn create_button(label: &str, id: &str, color: Color, hover_color: Color) -> ComponentSpecification {
+    Container::new()
+        .border_width("1px", "2px", "3px", "4px")
+        .border_color(Color::from_rgb8(0, 0, 0))
+        .border_radius(10.0, 10.0, 10.0, 10.0)
+        .padding("15px", "30px", "15px", "30px")
+        .background(color)
+        .display(Display::Flex)
+        .justify_content(JustifyContent::Center)
+        .align_items(AlignItems::Center)
+        .hovered()
+        .background(hover_color)
+        .push(Text::new(label).id(id).font_size(24.0).color(Color::WHITE).width("100%").height("100%"))
+        .id(id)
+        .component()
+}
+
+#[allow(dead_code)]
+#[cfg(not(target_os = "android"))]
+fn main() {
+    setup_logging();
+
+    craft_main_with_options(
+        OverlayExample::component(),
+        Box::new(()),
+        Some(CraftOptions {
+            renderer: RendererType::default(),
+            window_title: "Overlay".to_string(),
+        }),
+    );
+}
+
+#[cfg(target_os = "android")]
+use craft::AndroidApp;
+use craft_core::elements::Overlay;
+use craft_core::style::{Position, Unit};
+use util::setup_logging;
+
+#[allow(dead_code)]
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+fn android_main(app: AndroidApp) {
+    setup_logging();
+
+    craft_main_with_options(
+        OverlayExample::component(),
+        Box::new(()),
+        Some(CraftOptions {
+            renderer: RendererType::default(),
+            window_title: "Overlay".to_string(),
+        }),
+        app,
+    );
+}


### PR DESCRIPTION
Changes:
- Moves render command recording into a portable and light-weight `RenderList` struct.
- Adds two new draw commands: StartOverlay, EndOverlay
- Adds structs and methods for sorting the render commands.
- When dispatching events, visual order is now determined by sorting by the tree position then the overlay depth.
- Adds an overlay example.