### PR TITLE
Feature/move to layout item

### DIFF
--- a/crates/craft_core/src/elements/canvas.rs
+++ b/crates/craft_core/src/elements/canvas.rs
@@ -53,21 +53,21 @@ impl Element for Canvas {
             return;
         }
         let _border_color: Color = self.style().border_color().top;
-        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
+        let computed_box_transformed = self.computed_box_transformed();
         let _border_rectangle = computed_box_transformed.border_rectangle();
         let _content_rectangle = computed_box_transformed.content_rectangle();
 
         // background
-        let computed_x_transformed = self.element_data.layout_item.computed_box_transformed.position.x;
-        let computed_y_transformed = self.element_data.layout_item.computed_box_transformed.position.y;
+        let computed_x_transformed = self.computed_box_transformed().position.x;
+        let computed_y_transformed = self.computed_box_transformed().position.y;
 
-        let computed_width = self.element_data.layout_item.computed_box_transformed.size.width;
-        let computed_height = self.element_data.layout_item.computed_box_transformed.size.height;
+        let computed_width = self.computed_box_transformed().size.width;
+        let computed_height = self.computed_box_transformed().size.height;
 
-        let border_top = self.element_data.layout_item.computed_box_transformed.border.top;
-        let border_right = self.element_data.layout_item.computed_box_transformed.border.right;
-        let border_bottom = self.element_data.layout_item.computed_box_transformed.border.bottom;
-        let border_left = self.element_data.layout_item.computed_box_transformed.border.left;
+        let border_top = self.computed_box_transformed().border.top;
+        let border_right = self.computed_box_transformed().border.right;
+        let border_bottom = self.computed_box_transformed().border.bottom;
+        let border_left = self.computed_box_transformed().border.left;
 
         self.draw_borders(renderer, element_state);
 
@@ -153,7 +153,7 @@ impl Element for Canvas {
         scale_factor: f64,
     ) -> Option<NodeId> {
         self.merge_default_style();
-        
+
         for child in self.element_data.children.iter_mut() {
             let child_node = child.internal.compute_layout(taffy_tree, element_state, scale_factor);
             self.element_data.layout_item.push_child(&child_node);

--- a/crates/craft_core/src/elements/container.rs
+++ b/crates/craft_core/src/elements/container.rs
@@ -77,21 +77,21 @@ impl Element for Container {
         scale_factor: f64,
     ) -> Option<NodeId> {
         self.merge_default_style();
-        
+
         for child in &mut self.element_data.children {
             let child_node =
                 child.internal.compute_layout(taffy_tree, element_state, scale_factor);
             self.element_data.layout_item.push_child(&child_node);
         }
-        
+
         let base_state = self.get_base_state_mut(element_state);
         base_state.base.current_style_mut(&mut self.element_data).scale(scale_factor);
-        
+
         let current_style = {
             let base_state = self.get_base_state(element_state);
             base_state.base.current_style(&self.element_data).to_taffy_style()
         };
-        
+
         self.element_data.layout_item.build_tree(taffy_tree, current_style)
     }
 

--- a/crates/craft_core/src/elements/container.rs
+++ b/crates/craft_core/src/elements/container.rs
@@ -110,7 +110,6 @@ impl Element for Container {
     ) {
         let result = taffy_tree.layout(root_node).unwrap();
         self.resolve_box(position, transform, result, z_index);
-
         self.finalize_borders(element_state);
 
         self.element_data.layout_item.scrollbar_size = Size::new(result.scrollbar_size.width, result.scrollbar_size.height);

--- a/crates/craft_core/src/elements/dropdown.rs
+++ b/crates/craft_core/src/elements/dropdown.rs
@@ -229,7 +229,7 @@ impl Element for Dropdown {
             self.pseudo_dropdown_list_element.finalize_layout(
                 taffy_tree,
                 dropdown_list,
-                self.element_data.layout_item.computed_box.position,
+                self.computed_box().position,
                 z_index,
                 transform,
                 element_state,

--- a/crates/craft_core/src/elements/element.rs
+++ b/crates/craft_core/src/elements/element.rs
@@ -66,10 +66,6 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
         self.element_data().component_id
     }
 
-    fn taffy_node_id(&self) -> Option<NodeId> {
-        self.element_data().layout_item.taffy_node_id
-    }
-
     fn set_component_id(&mut self, id: u64) {
         self.element_data_mut().component_id = id;
     }
@@ -294,7 +290,7 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
             return;
         }
 
-        let element_rect = self.element_data().layout_item.computed_box_transformed;
+        let element_rect = self.computed_box_transformed();
         let borders = element_rect.border;
         let border_spec = BorderSpec::new(
             element_rect.border_rectangle(),
@@ -398,6 +394,20 @@ pub trait Element: Any + StandardElementClone + Send + Sync {
 
     fn merge_default_style(&mut self) {
         self.element_data_mut().style = Style::merge(&self.default_style(), &self.element_data().style);
+    }
+
+    
+    // Easy ways to access common items from layout item:
+    fn taffy_node_id(&self) -> Option<NodeId> {
+        self.element_data().layout_item.taffy_node_id
+    }
+    
+    fn computed_box(&self) -> ElementBox {
+        self.element_data().layout_item.computed_box
+    }
+    
+    fn computed_box_transformed(&self) -> ElementBox {
+        self.element_data().layout_item.computed_box_transformed
     }
 }
 

--- a/crates/craft_core/src/elements/element_data.rs
+++ b/crates/craft_core/src/elements/element_data.rs
@@ -3,7 +3,6 @@ use crate::components::{Event, Props};
 use crate::elements::element::ElementBoxed;
 use crate::elements::element_states::ElementState;
 use crate::events::{KeyboardInput, MouseWheel, PointerButton, PointerMoved};
-use crate::geometry::borders::ComputedBorderSpec;
 use crate::layout::layout_item::LayoutItem;
 use crate::style::Style;
 use std::any::Any;
@@ -19,8 +18,6 @@ pub(crate) type EventHandlerCopy<Arg> = Arc<dyn Fn(&mut dyn Any, &mut dyn Any, &
 #[derive(Clone, Default)]
 pub struct ElementData {
     pub current_state: ElementState,
-
-    pub computed_border: ComputedBorderSpec,
 
     /// The style of the element.
     pub style: Style,

--- a/crates/craft_core/src/elements/element_data.rs
+++ b/crates/craft_core/src/elements/element_data.rs
@@ -4,11 +4,10 @@ use crate::elements::element::ElementBoxed;
 use crate::elements::element_states::ElementState;
 use crate::events::{KeyboardInput, MouseWheel, PointerButton, PointerMoved};
 use crate::geometry::borders::ComputedBorderSpec;
-use crate::geometry::{ElementBox, Rectangle, Size};
+use crate::layout::layout_item::LayoutItem;
 use crate::style::Style;
 use std::any::Any;
 use std::sync::Arc;
-use taffy::NodeId;
 use winit::event::{Ime, Modifiers};
 
 pub(crate) type EventHandler = Arc<dyn Fn(&mut dyn Any, &mut dyn Any, &mut Event) + Send + Sync + 'static>;
@@ -25,6 +24,8 @@ pub struct ElementData {
 
     /// The style of the element.
     pub style: Style,
+    
+    pub layout_item: LayoutItem,
 
     /// The style of the element when it is hovered.
     pub hover_style: Option<Box<Style>>,
@@ -40,28 +41,12 @@ pub struct ElementData {
 
     /// The children of the element.
     pub children: Vec<ElementBoxed>,
-
-    /// The taffy node id after this element is laid out.
-    /// This may be None if this is a non-visual element like Font.
-    pub taffy_node_id: Option<NodeId>,
-
-    pub content_size: Size<f32>,
-    // The computed values after transforms are applied.
-    pub computed_box_transformed: ElementBox,
-    // The computed values without any transforms applied to them.
-    pub computed_box: ElementBox,
-
+    
     /// A user-defined id for the element.
     pub id: Option<String>,
 
     /// The id of the component that this element belongs to.
     pub component_id: ComponentId,
-    pub computed_scrollbar_size: Size<f32>,
-    pub scrollbar_size: Size<f32>,
-    pub computed_scroll_track: Rectangle,
-    pub computed_scroll_thumb: Rectangle,
-    pub(crate) max_scroll_y: f32,
-    pub layout_order: u32,
 
     // Used for converting the element to a component specification.
     pub child_specs: Vec<ComponentSpecification>,
@@ -81,7 +66,6 @@ pub struct ElementData {
     pub(crate) on_dropdown_item_selected: Option<EventHandlerCopy<usize>>,
     pub(crate) on_switch_toggled: Option<EventHandlerCopy<bool>>,
     pub(crate) on_slider_value_changed: Option<EventHandlerCopy<f64>>,
-    pub(crate) clip_bounds: Option<Rectangle>,
 }
 
 impl ElementData {

--- a/crates/craft_core/src/elements/image.rs
+++ b/crates/craft_core/src/elements/image.rs
@@ -61,7 +61,7 @@ impl Element for Image {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
+        let computed_box_transformed = self.computed_box_transformed();
         let content_rectangle = computed_box_transformed.content_rectangle();
         self.draw_borders(renderer, element_state);
 

--- a/crates/craft_core/src/elements/image.rs
+++ b/crates/craft_core/src/elements/image.rs
@@ -61,7 +61,7 @@ impl Element for Image {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.computed_box_transformed;
+        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
         let content_rectangle = computed_box_transformed.content_rectangle();
         self.draw_borders(renderer, element_state);
 
@@ -77,19 +77,14 @@ impl Element for Image {
         self.merge_default_style();
         self.element_data.style.scale(scale_factor);
         let style: taffy::Style = self.element_data.style.to_taffy_style();
-
-        self.element_data_mut().taffy_node_id = Some(
-            taffy_tree
-                .new_leaf_with_context(
-                    style,
-                    LayoutContext::Image(ImageContext {
-                        resource_identifier: self.resource_identifier.clone(),
-                    }),
-                )
-                .unwrap(),
-        );
-
-        self.element_data().taffy_node_id
+        
+        self.element_data.layout_item.build_tree_with_context(
+            taffy_tree,
+            style,
+            LayoutContext::Image(ImageContext {
+                resource_identifier: self.resource_identifier.clone(),
+            }),
+        )
     }
 
     fn finalize_layout(

--- a/crates/craft_core/src/elements/scroll_state.rs
+++ b/crates/craft_core/src/elements/scroll_state.rs
@@ -32,7 +32,7 @@ impl ScrollState {
                     };
                     let delta = -delta;
                     // Todo: Scroll physics
-                    let max_scroll_y = element.max_scroll_y;
+                    let max_scroll_y = element.layout_item.max_scroll_y;
 
                     self.scroll_y = (self.scroll_y + delta).clamp(0.0, max_scroll_y);
 
@@ -43,9 +43,9 @@ impl ScrollState {
                     if pointer_button.button.mouse_button() == MouseButton::Left {
                         // DEVICE(TOUCH): Handle scrolling within the content area on touch based input devices.
                         if let ButtonSource::Touch { .. } = pointer_button.button {
-                            let container_rectangle = element.computed_box_transformed.padding_rectangle();
+                            let container_rectangle = element.layout_item.computed_box_transformed.padding_rectangle();
 
-                            let in_scroll_bar = element.computed_scroll_thumb.contains(&pointer_button.position);
+                            let in_scroll_bar = element.layout_item.computed_scroll_thumb.contains(&pointer_button.position);
 
                             if container_rectangle.contains(&pointer_button.position) && !in_scroll_bar {
                                 self.scroll_click = Some((pointer_button.position.x, pointer_button.position.y));
@@ -57,20 +57,20 @@ impl ScrollState {
 
                         match pointer_button.state {
                             WinitElementState::Pressed => {
-                                if element.computed_scroll_thumb.contains(&pointer_button.position) {
+                                if element.layout_item.computed_scroll_thumb.contains(&pointer_button.position) {
                                     self.scroll_click = Some((pointer_button.position.x, pointer_button.position.y));
                                     // FIXME: Turn pointer capture on with the correct device id.
                                     base_state.pointer_capture.insert(DUMMY_DEVICE_ID, true);
 
                                     event.prevent_propagate();
                                     event.prevent_defaults();
-                                } else if element.computed_scroll_track.contains(&pointer_button.position) {
-                                    let offset_y = pointer_button.position.y - element.computed_scroll_track.y;
+                                } else if element.layout_item.computed_scroll_track.contains(&pointer_button.position) {
+                                    let offset_y = pointer_button.position.y - element.layout_item.computed_scroll_track.y;
 
-                                    let percent = offset_y / element.computed_scroll_track.height;
-                                    let scroll_y = percent * element.max_scroll_y;
+                                    let percent = offset_y / element.layout_item.computed_scroll_track.height;
+                                    let scroll_y = percent * element.layout_item.max_scroll_y;
 
-                                    self.scroll_y = scroll_y.clamp(0.0, element.max_scroll_y);
+                                    self.scroll_y = scroll_y.clamp(0.0, element.layout_item.max_scroll_y);
 
                                     event.prevent_propagate();
                                     event.prevent_defaults();
@@ -93,10 +93,10 @@ impl ScrollState {
                         // Todo: Translate scroll wheel pixel to scroll position for diff.
                         let delta = pointer_motion.position.y - click_y;
 
-                        let max_scroll_y = element.max_scroll_y;
+                        let max_scroll_y = element.layout_item.max_scroll_y;
 
                         let mut delta = max_scroll_y
-                            * (delta / (element.computed_scroll_track.height - element.computed_scroll_thumb.height));
+                            * (delta / (element.layout_item.computed_scroll_track.height - element.layout_item.computed_scroll_thumb.height));
 
                         // DEVICE(TOUCH): Reverse the direction on touch based input devices.
                         if let PointerSource::Touch { .. } = pointer_motion.source {

--- a/crates/craft_core/src/elements/slider.rs
+++ b/crates/craft_core/src/elements/slider.rs
@@ -85,13 +85,13 @@ impl Element for Slider {
         // Draw the value track color to the left of the thumb.
         if let Some(value_track_color) = self.value_track_color {
             let element_data = self.element_data();
-            let mut element_rect = self.element_data().layout_item.computed_box_transformed;
+            let mut element_rect = self.computed_box_transformed();
 
             let borders = element_rect.border;
             let border_radius = element_data.current_style().border_radius();
 
             if self.direction == SliderDirection::Horizontal {
-                element_rect.size.width = self.thumb.pseudo_thumb.element_data.layout_item.computed_box_transformed.position.x - self.element_data().layout_item.computed_box_transformed.position.x;
+                element_rect.size.width = self.thumb.pseudo_thumb.computed_box_transformed().position.x - self.computed_box_transformed().position.x;
 
                 // HACK: When the value track is visible add some extra width to make sure there are no gaps in the value track color.
                 // The background track may show through on the left edge if the thumb is round.
@@ -99,7 +99,7 @@ impl Element for Slider {
                     element_rect.size.width += self.thumb.size / 2.0;
                 }
             } else {
-                element_rect.size.height = self.thumb.pseudo_thumb.element_data.layout_item.computed_box_transformed.position.y - self.element_data().layout_item.computed_box_transformed.position.y;
+                element_rect.size.height = self.thumb.pseudo_thumb.computed_box_transformed().position.y - self.computed_box_transformed().position.y;
 
                 // HACK: When the value track is visible add some extra height to make sure there are no gaps in the value track color.
                 // The background track may show through on the top edge if the thumb is round.
@@ -251,7 +251,7 @@ impl Slider {
     }
 
     fn thumb_position(&self, thumb_value: f64) -> Point {
-        let content_rectangle = self.element_data.layout_item.computed_box.content_rectangle();
+        let content_rectangle = self.computed_box().content_rectangle();
         
         let mut normalized_value = thumb_value / self.max;
         normalized_value = normalized_value.clamp(0.0, 1.0);
@@ -322,7 +322,7 @@ impl Slider {
     }
 
     fn compute_slider_value(&self, pointer_position: &Point) -> f64 {
-        let content_rectangle = self.element_data.layout_item.computed_box.content_rectangle();
+        let content_rectangle = self.computed_box().content_rectangle();
         let start = if self.direction == SliderDirection::Horizontal { content_rectangle.left() as f64 } else { content_rectangle.top() as f64 };
         let end = if self.direction == SliderDirection::Horizontal { content_rectangle.right() as f64 } else { content_rectangle.bottom() as f64 };
 

--- a/crates/craft_core/src/elements/slider.rs
+++ b/crates/craft_core/src/elements/slider.rs
@@ -69,12 +69,12 @@ impl Element for Slider {
     fn draw(
         &mut self,
         renderer: &mut RenderList,
-        text_context: &mut TextContext,
-        taffy_tree: &mut TaffyTree<LayoutContext>,
+        _text_context: &mut TextContext,
+        _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,
         element_state: &mut ElementStateStore,
-        pointer: Option<Point>,
-        window: Option<Arc<dyn Window>>,
+        _pointer: Option<Point>,
+        _window: Option<Arc<dyn Window>>,
     ) {
         if !self.element_data.style.visible() {
             return;
@@ -91,7 +91,7 @@ impl Element for Slider {
             let border_radius = element_data.current_style().border_radius();
 
             if self.direction == SliderDirection::Horizontal {
-                element_rect.size.width = self.thumb.pseudo_thumb.computed_box_transformed().position.x - self.computed_box_transformed().position.x;
+                element_rect.size.width = self.thumb.layout_item.computed_box_transformed.position.x - self.computed_box_transformed().position.x;
 
                 // HACK: When the value track is visible add some extra width to make sure there are no gaps in the value track color.
                 // The background track may show through on the left edge if the thumb is round.
@@ -99,7 +99,7 @@ impl Element for Slider {
                     element_rect.size.width += self.thumb.size / 2.0;
                 }
             } else {
-                element_rect.size.height = self.thumb.pseudo_thumb.computed_box_transformed().position.y - self.computed_box_transformed().position.y;
+                element_rect.size.height = self.thumb.layout_item.computed_box_transformed.position.y - self.computed_box_transformed().position.y;
 
                 // HACK: When the value track is visible add some extra height to make sure there are no gaps in the value track color.
                 // The background track may show through on the top edge if the thumb is round.
@@ -119,17 +119,17 @@ impl Element for Slider {
             renderer.fill_bez_path(background_path, Brush::Color(value_track_color));
         }
 
-        self.thumb.pseudo_thumb.draw(renderer, text_context, taffy_tree, _root_node, element_state, pointer, window);
+        self.thumb.draw(renderer);
     }
 
     fn compute_layout(
         &mut self,
         taffy_tree: &mut TaffyTree<LayoutContext>,
-        element_state: &mut ElementStateStore,
+        _element_state: &mut ElementStateStore,
         scale_factor: f64,
     ) -> Option<NodeId> {
         self.merge_default_style();
-        let child_node = self.thumb.compute_layout(taffy_tree, element_state, scale_factor, false, self.rounded);
+        let child_node = self.thumb.compute_layout(taffy_tree, scale_factor, false, self.rounded);
         self.element_data.layout_item.push_child(&Some(child_node));
         
         self.thumb.size *= scale_factor as f32;
@@ -167,6 +167,7 @@ impl Element for Slider {
             element_state,
             pointer,
             text_context,
+            clip_bounds,
         );
     }
 
@@ -342,7 +343,8 @@ impl Slider {
 
     pub fn new(thumb_size: f32) -> Slider {
         let mut thumb = Thumb {
-            pseudo_thumb: Default::default(),
+            layout_item: Default::default(),
+            thumb_style: Default::default(),
             toggled_thumb_style: Default::default(),
             size: thumb_size,
         };

--- a/crates/craft_core/src/elements/switch.rs
+++ b/crates/craft_core/src/elements/switch.rs
@@ -58,18 +58,18 @@ impl Element for Switch {
     fn draw(
         &mut self,
         renderer: &mut RenderList,
-        text_context: &mut TextContext,
-        taffy_tree: &mut TaffyTree<LayoutContext>,
+        _text_context: &mut TextContext,
+        _taffy_tree: &mut TaffyTree<LayoutContext>,
         _root_node: NodeId,
         element_state: &mut ElementStateStore,
-        pointer: Option<Point>,
-        window: Option<Arc<dyn Window>>,
+        _pointer: Option<Point>,
+        _window: Option<Arc<dyn Window>>,
     ) {
         if !self.element_data.style.visible() {
             return;
         }
         self.draw_borders(renderer, element_state);
-        self.thumb.pseudo_thumb.draw(renderer, text_context, taffy_tree, _root_node, element_state, pointer, window);
+        self.thumb.draw(renderer);
     }
 
     fn compute_layout(
@@ -96,7 +96,7 @@ impl Element for Switch {
             set_toggled_styles();
         }
 
-        let child_node = self.thumb.compute_layout(taffy_tree, element_state, scale_factor, state.toggled.unwrap_or(default_toggled), self.rounded);
+        let child_node = self.thumb.compute_layout(taffy_tree, scale_factor, state.toggled.unwrap_or(default_toggled), self.rounded);
         self.element_data.layout_item.push_child(&Some(child_node));
         
         self.thumb.size *= scale_factor as f32;
@@ -141,6 +141,7 @@ impl Element for Switch {
             element_state,
             pointer,
             text_context,
+            clip_bounds
         );
     }
 
@@ -262,7 +263,8 @@ impl Switch {
             element_data: Default::default(),
             default_toggled: false,
             thumb: Thumb {
-                pseudo_thumb: Default::default(),
+                layout_item: Default::default(),
+                thumb_style: Default::default(),
                 toggled_thumb_style: Default::default(),
                 size,
             },

--- a/crates/craft_core/src/elements/switch.rs
+++ b/crates/craft_core/src/elements/switch.rs
@@ -97,14 +97,15 @@ impl Element for Switch {
         }
 
         let child_node = self.thumb.compute_layout(taffy_tree, element_state, scale_factor, state.toggled.unwrap_or(default_toggled), self.rounded);
+        self.element_data.layout_item.push_child(&Some(child_node));
         
         self.thumb.size *= scale_factor as f32;
         self.spacing *= scale_factor as f32;
 
         self.element_data.style.scale(scale_factor);
         let style: taffy::Style = self.element_data.style.to_taffy_style();
-        self.element_data_mut().taffy_node_id = Some(taffy_tree.new_with_children(style, &[child_node]).unwrap());
-        self.element_data().taffy_node_id
+        
+        self.element_data.layout_item.build_tree(taffy_tree, style)
     }
 
     fn finalize_layout(
@@ -126,11 +127,11 @@ impl Element for Switch {
         self.finalize_borders(element_state);
         
         let x = if state.toggled.unwrap_or(self.default_toggled) {
-            self.element_data.computed_box.content_rectangle().right() - self.spacing - self.thumb.size
+            self.element_data.layout_item.computed_box.content_rectangle().right() - self.spacing - self.thumb.size
         } else {
-            self.element_data.computed_box.content_rectangle().left() + self.spacing
+            self.element_data.layout_item.computed_box.content_rectangle().left() + self.spacing
         };
-        let y = self.element_data.computed_box.content_rectangle().top() + self.spacing;
+        let y = self.element_data.layout_item.computed_box.content_rectangle().top() + self.spacing;
         
         self.thumb.finalize_layout(
             taffy_tree,

--- a/crates/craft_core/src/elements/switch.rs
+++ b/crates/craft_core/src/elements/switch.rs
@@ -127,11 +127,11 @@ impl Element for Switch {
         self.finalize_borders(element_state);
         
         let x = if state.toggled.unwrap_or(self.default_toggled) {
-            self.element_data.layout_item.computed_box.content_rectangle().right() - self.spacing - self.thumb.size
+            self.computed_box().content_rectangle().right() - self.spacing - self.thumb.size
         } else {
-            self.element_data.layout_item.computed_box.content_rectangle().left() + self.spacing
+            self.computed_box().content_rectangle().left() + self.spacing
         };
-        let y = self.element_data.layout_item.computed_box.content_rectangle().top() + self.spacing;
+        let y = self.computed_box().content_rectangle().top() + self.spacing;
         
         self.thumb.finalize_layout(
             taffy_tree,

--- a/crates/craft_core/src/elements/text.rs
+++ b/crates/craft_core/src/elements/text.rs
@@ -103,7 +103,7 @@ impl Element for Text {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.computed_box_transformed;
+        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
         let content_rectangle = computed_box_transformed.content_rectangle();
 
         self.draw_borders(renderer, element_state);
@@ -133,16 +133,12 @@ impl Element for Text {
         self.element_data.style.scale(scale_factor);
         let style: taffy::Style = self.element_data.style.to_taffy_style();
 
-        self.element_data_mut().taffy_node_id = Some(
-            taffy_tree
-                .new_leaf_with_context(
-                    style,
-                    LayoutContext::Text(TaffyTextContext::new(self.element_data.component_id)),
-                )
-                .unwrap(),
-        );
-
-        self.element_data().taffy_node_id
+        
+        self.element_data.layout_item.build_tree_with_context(
+            taffy_tree, 
+            style,
+            LayoutContext::Text(TaffyTextContext::new(self.element_data.component_id))
+        )
     }
 
     fn finalize_layout(
@@ -211,11 +207,11 @@ impl Element for Text {
             .downcast_mut()
             .unwrap();
 
-        let _content_rect = self.element_data.computed_box.content_rectangle();
+        let _content_rect = self.element_data.layout_item.computed_box.content_rectangle();
 
         // Handle selection.
         if self.selectable {
-            let text_position = self.element_data().computed_box_transformed.content_rectangle();
+            let text_position = self.element_data().layout_item.computed_box_transformed.content_rectangle();
 
             match message {
                 CraftMessage::PointerButtonEvent(pointer_button) => {

--- a/crates/craft_core/src/elements/text.rs
+++ b/crates/craft_core/src/elements/text.rs
@@ -103,7 +103,7 @@ impl Element for Text {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
+        let computed_box_transformed = self.computed_box_transformed();
         let content_rectangle = computed_box_transformed.content_rectangle();
 
         self.draw_borders(renderer, element_state);
@@ -207,11 +207,11 @@ impl Element for Text {
             .downcast_mut()
             .unwrap();
 
-        let _content_rect = self.element_data.layout_item.computed_box.content_rectangle();
+        let _content_rect = self.computed_box().content_rectangle();
 
         // Handle selection.
         if self.selectable {
-            let text_position = self.element_data().layout_item.computed_box_transformed.content_rectangle();
+            let text_position = self.computed_box_transformed().content_rectangle();
 
             match message {
                 CraftMessage::PointerButtonEvent(pointer_button) => {

--- a/crates/craft_core/src/elements/text_input.rs
+++ b/crates/craft_core/src/elements/text_input.rs
@@ -117,7 +117,7 @@ impl Element for TextInput {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.computed_box_transformed;
+        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
         let content_rectangle = computed_box_transformed.content_rectangle();
 
         self.draw_borders(renderer, element_state);
@@ -125,7 +125,7 @@ impl Element for TextInput {
         let is_scrollable = self.element_data.is_scrollable();
 
         let element_data = self.element_data();
-        let padding_rectangle = element_data.computed_box_transformed.padding_rectangle();
+        let padding_rectangle = element_data.layout_item.computed_box_transformed.padding_rectangle();
         renderer.push_layer(padding_rectangle);
 
         let scroll_y = if let Some(state) =
@@ -137,7 +137,7 @@ impl Element for TextInput {
         };
 
         let text_scroll = if is_scrollable {
-            Some(TextScroll::new(scroll_y, self.element_data.computed_scroll_track.height))
+            Some(TextScroll::new(scroll_y, self.element_data.layout_item.computed_scroll_track.height))
         } else {
             None
         };
@@ -165,16 +165,11 @@ impl Element for TextInput {
         self.element_data.style.scale(scale_factor);
         let style: taffy::Style = self.element_data.style.to_taffy_style();
 
-        self.element_data_mut().taffy_node_id = Some(
-            taffy_tree
-                .new_leaf_with_context(
-                    style,
-                    LayoutContext::TextInput(TaffyTextInputContext::new(self.element_data.component_id)),
-                )
-                .unwrap(),
-        );
-
-        self.element_data().taffy_node_id
+        self.element_data.layout_item.build_tree_with_context(
+            taffy_tree,
+            style,
+            LayoutContext::TextInput(TaffyTextInputContext::new(self.element_data.component_id))
+        )
     }
 
     fn finalize_layout(
@@ -222,8 +217,8 @@ impl Element for TextInput {
         });
         text_renderer.cursor = state.editor.cursor_geometry(1.0).map(|r| r.into());
 
-        self.element_data.scrollbar_size = Size::new(result.scrollbar_size.width, result.scrollbar_size.height);
-        self.element_data.computed_scrollbar_size = Size::new(result.scroll_width(), result.scroll_height());
+        self.element_data.layout_item.scrollbar_size = Size::new(result.scrollbar_size.width, result.scrollbar_size.height);
+        self.element_data.layout_item.computed_scrollbar_size = Size::new(result.scroll_width(), result.scroll_height());
 
         let scroll_y = if let Some(state) =
             element_state.storage.get(&self.element_data.component_id).unwrap().data.downcast_ref::<TextInputState>()
@@ -266,7 +261,7 @@ impl Element for TextInput {
 
         let scroll_y = state.scroll_state.scroll_y;
 
-        let text_position = self.element_data().computed_box_transformed.content_rectangle();
+        let text_position = self.element_data().layout_item.computed_box_transformed.content_rectangle();
         let text_x = text_position.x;
         let text_y = text_position.y;
         let state: &mut TextInputState = element_state

--- a/crates/craft_core/src/elements/text_input.rs
+++ b/crates/craft_core/src/elements/text_input.rs
@@ -117,7 +117,7 @@ impl Element for TextInput {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
+        let computed_box_transformed = self.computed_box_transformed();
         let content_rectangle = computed_box_transformed.content_rectangle();
 
         self.draw_borders(renderer, element_state);
@@ -261,7 +261,7 @@ impl Element for TextInput {
 
         let scroll_y = state.scroll_state.scroll_y;
 
-        let text_position = self.element_data().layout_item.computed_box_transformed.content_rectangle();
+        let text_position = self.computed_box_transformed().content_rectangle();
         let text_x = text_position.x;
         let text_y = text_position.y;
         let state: &mut TextInputState = element_state

--- a/crates/craft_core/src/elements/thumb.rs
+++ b/crates/craft_core/src/elements/thumb.rs
@@ -78,7 +78,7 @@ impl Thumb {
     ) {
         self.pseudo_thumb.finalize_layout(
             taffy_tree,
-            self.pseudo_thumb.element_data.taffy_node_id.unwrap(),
+            self.pseudo_thumb.element_data.layout_item.taffy_node_id.unwrap(),
             position,
             z_index,
             transform,

--- a/crates/craft_core/src/elements/thumb.rs
+++ b/crates/craft_core/src/elements/thumb.rs
@@ -1,19 +1,20 @@
-use taffy::{NodeId, Position, TaffyTree};
-use crate::elements::Container;
-use crate::elements::element::Element;
+use crate::geometry::{Point, Rectangle};
 use crate::layout::layout_context::LayoutContext;
-use crate::geometry::Point;
+use crate::layout::layout_item::LayoutItem;
 use crate::palette;
 use crate::reactive::element_state_store::ElementStateStore;
+use crate::renderer::RenderList;
 use crate::style::{Display, Style, Unit};
 use crate::text::text_context::TextContext;
+use taffy::{NodeId, Position, TaffyTree};
 
 #[derive(Clone)]
 pub(crate) struct Thumb {
     /// A pseudo thumb element, this is not stored in the user tree nor will it receive events.
     /// This is mostly for convenience, so that we can change the location and render it in the switch track container.
-    pub(crate) pseudo_thumb: Container,
+    pub(crate) layout_item: LayoutItem,
     /// The style of the thumb when the switch is toggled. This style will get merged with the default style + user style.
+    pub(crate) thumb_style: Style,
     pub(crate) toggled_thumb_style: Style,
     /// The size of the thumb in pixels.
     pub(crate) size: f32,
@@ -43,7 +44,7 @@ impl Thumb {
     }
 
     pub(crate) fn thumb_style(&mut self, thumb_style: Style) {
-        self.pseudo_thumb.element_data_mut().style = thumb_style;
+        self.thumb_style = thumb_style;
     }
 
     pub(crate) fn toggled_thumb_style(&mut self, toggled_thumb_style: Style) {
@@ -51,19 +52,16 @@ impl Thumb {
     }
 
     pub(crate) fn compute_layout(&mut self, taffy_tree: &mut TaffyTree<LayoutContext>,
-                          element_state: &mut ElementStateStore,
                           scale_factor: f64, toggled: bool, rounded: bool) -> NodeId {
-        self.pseudo_thumb.element_data_mut().style =
-            Style::merge(&self.default_thumb_style(rounded), &self.pseudo_thumb.element_data_mut().style);
+        self.thumb_style = Style::merge(&self.default_thumb_style(rounded), &self.thumb_style);
 
         if toggled {
-            self.pseudo_thumb.element_data_mut().style =
-                Style::merge(&self.pseudo_thumb.element_data().style, &self.default_toggled_thumb_style(rounded));
-            self.pseudo_thumb.element_data_mut().style =
-                Style::merge(&self.pseudo_thumb.element_data().style, &self.toggled_thumb_style);
+            self.thumb_style = Style::merge(&self.thumb_style, &self.default_toggled_thumb_style(rounded));
+            self.thumb_style = Style::merge(&self.thumb_style, &self.toggled_thumb_style);
         }
 
-        self.pseudo_thumb.compute_layout(taffy_tree, element_state, scale_factor).unwrap()
+        self.thumb_style.scale(scale_factor);
+        self.layout_item.build_tree(taffy_tree, self.thumb_style.to_taffy_style()).unwrap()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -72,20 +70,22 @@ impl Thumb {
         position: Point,
         z_index: &mut u32,
         transform: glam::Mat4,
-        element_state: &mut ElementStateStore,
-        pointer: Option<Point>,
-        text_context: &mut TextContext,
+        _element_state: &mut ElementStateStore,
+        _pointer: Option<Point>,
+        _text_context: &mut TextContext,
+        clip_bounds: Option<Rectangle>,
     ) {
-        self.pseudo_thumb.finalize_layout(
-            taffy_tree,
-            self.pseudo_thumb.element_data.layout_item.taffy_node_id.unwrap(),
-            position,
-            z_index,
-            transform,
-            element_state,
-            pointer,
-            text_context,
-            None,
-        );
+        let result = taffy_tree.layout(self.layout_item.taffy_node_id.unwrap()).unwrap();
+        self.layout_item.resolve_box(position, transform, result, z_index, self.thumb_style.position());
+        self.layout_item.finalize_borders(self.thumb_style.has_border(), self.thumb_style.border_radius(), self.thumb_style.border_color());
+        self.layout_item.resolve_clip(clip_bounds);
+    }
+    
+    pub(crate) fn draw(&mut self, renderer: &mut RenderList) {
+        if !self.thumb_style.visible() {
+            return;
+        }
+        
+        self.layout_item.draw_borders(renderer, &self.thumb_style);
     }
 }

--- a/crates/craft_core/src/elements/tinyvg.rs
+++ b/crates/craft_core/src/elements/tinyvg.rs
@@ -62,7 +62,7 @@ impl Element for TinyVg {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.computed_box_transformed;
+        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
         let content_rectangle = computed_box_transformed.content_rectangle();
         self.draw_borders(renderer, element_state);
         
@@ -84,18 +84,14 @@ impl Element for TinyVg {
         self.element_data.style.scale(scale_factor);
         let style: taffy::Style = self.element_data.style.to_taffy_style();
 
-        self.element_data_mut().taffy_node_id = Some(
-            taffy_tree
-                .new_leaf_with_context(
-                    style,
-                    LayoutContext::TinyVg(TinyVgContext {
-                        resource_identifier: self.resource_identifier.clone(),
-                    }),
-                )
-                .unwrap(),
-        );
-
-        self.element_data().taffy_node_id
+        
+        self.element_data.layout_item.build_tree_with_context(
+            taffy_tree,
+            style,
+            LayoutContext::TinyVg(TinyVgContext {
+                resource_identifier: self.resource_identifier.clone(),
+            })
+        )
     }
 
     fn finalize_layout(

--- a/crates/craft_core/src/elements/tinyvg.rs
+++ b/crates/craft_core/src/elements/tinyvg.rs
@@ -62,7 +62,7 @@ impl Element for TinyVg {
         if !self.element_data.style.visible() {
             return;
         }
-        let computed_box_transformed = self.element_data.layout_item.computed_box_transformed;
+        let computed_box_transformed = self.computed_box_transformed();
         let content_rectangle = computed_box_transformed.content_rectangle();
         self.draw_borders(renderer, element_state);
         

--- a/crates/craft_core/src/events/event_dispatch.rs
+++ b/crates/craft_core/src/events/event_dispatch.rs
@@ -113,7 +113,7 @@ pub(crate) fn dispatch_event(
 
                                 parent_component_targets.push_back(Target {
                                     component_id: node.id,
-                                    layout_order: element.element_data().layout_order as usize,
+                                    layout_order: element.element_data().layout_item.layout_order as usize,
                                     overlay_depth,
                                     element: Some(element),
                                     component: Some(node),
@@ -150,7 +150,7 @@ pub(crate) fn dispatch_event(
 
                         targets.push_back(Target {
                             component_id: element.component_id(),
-                            layout_order: element.element_data().layout_order as usize,
+                            layout_order: element.element_data().layout_item.layout_order as usize,
                             overlay_depth,
                             element: Some(element),
                             component: None,

--- a/crates/craft_core/src/layout/layout_item.rs
+++ b/crates/craft_core/src/layout/layout_item.rs
@@ -1,0 +1,50 @@
+use crate::geometry::{ElementBox, Rectangle, Size};
+use crate::layout::layout_context::LayoutContext;
+use taffy::{NodeId, TaffyTree};
+
+#[derive(Clone, Default)]
+pub struct LayoutItem {
+    /// The taffy node id after this element is laid out.
+    /// This may be None if this is a non-visual element like Font.
+    pub taffy_node_id: Option<NodeId>,
+
+    pub content_size: Size<f32>,
+    // The computed values after transforms are applied.
+    pub computed_box_transformed: ElementBox,
+    // The computed values without any transforms applied to them.
+    pub computed_box: ElementBox,
+    pub computed_scrollbar_size: Size<f32>,
+    pub scrollbar_size: Size<f32>,
+    pub computed_scroll_track: Rectangle,
+    pub computed_scroll_thumb: Rectangle,
+    pub(crate) max_scroll_y: f32,
+    
+    pub layout_order: u32,
+    pub clip_bounds: Option<Rectangle>,
+    
+    //  ---
+    pub child_nodes: Vec<NodeId>,
+}
+
+impl LayoutItem {
+    pub fn new() {
+        
+    }
+    
+    pub fn push_child(&mut self, child: &Option<NodeId>) {
+        if let Some(taffy_node_id) = child.as_ref() {
+            self.child_nodes.push(*taffy_node_id);   
+        }
+    }
+    pub fn build_tree(&mut self, taffy_tree: &mut TaffyTree<LayoutContext>, style: taffy::Style) -> Option<NodeId> {
+        self.taffy_node_id = Some(taffy_tree.new_with_children(style, &self.child_nodes).unwrap());
+        self.taffy_node_id.clone()
+    }
+    pub fn build_tree_with_context(&mut self,
+                                   taffy_tree: &mut TaffyTree<LayoutContext>,
+                                   style: taffy::Style,
+                                   layout_context: LayoutContext) -> Option<NodeId> {
+        self.taffy_node_id = Some(taffy_tree.new_leaf_with_context(style, layout_context).unwrap());
+        self.taffy_node_id.clone()
+    }
+}

--- a/crates/craft_core/src/layout/layout_item.rs
+++ b/crates/craft_core/src/layout/layout_item.rs
@@ -27,19 +27,18 @@ pub struct LayoutItem {
 }
 
 impl LayoutItem {
-    pub fn new() {
-        
-    }
     
     pub fn push_child(&mut self, child: &Option<NodeId>) {
         if let Some(taffy_node_id) = child.as_ref() {
             self.child_nodes.push(*taffy_node_id);   
         }
     }
+    
     pub fn build_tree(&mut self, taffy_tree: &mut TaffyTree<LayoutContext>, style: taffy::Style) -> Option<NodeId> {
         self.taffy_node_id = Some(taffy_tree.new_with_children(style, &self.child_nodes).unwrap());
         self.taffy_node_id.clone()
     }
+    
     pub fn build_tree_with_context(&mut self,
                                    taffy_tree: &mut TaffyTree<LayoutContext>,
                                    style: taffy::Style,

--- a/crates/craft_core/src/layout/mod.rs
+++ b/crates/craft_core/src/layout/mod.rs
@@ -1,1 +1,2 @@
 pub mod layout_context;
+pub mod layout_item;


### PR DESCRIPTION
Moves layout specific fields into a separate struct to enable light-weight layout items for things like sliders, dropdowns, and custom elements.